### PR TITLE
Support Laravel 10 through 13

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,21 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2]
-        laravel: [10.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
+            php: 8.2
             testbench: 8.*
-            carbon: ^2.63
+          - laravel: 11.*
+            php: 8.2
+            testbench: 9.*
+          - laravel: 12.*
+            php: 8.2
+            testbench: 10.*
+          - laravel: 13.*
+            php: 8.3
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -41,8 +49,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer require "laravel/framework:${{ matrix.laravel }}@stable" "orchestra/testbench:${{ matrix.testbench }}@stable" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-security-blocking
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,16 +18,16 @@ jobs:
         include:
           - laravel: 10.*
             php: 8.2
-            testbench: 8.*
+            testbench: ^8.13
           - laravel: 11.*
             php: 8.2
-            testbench: 9.*
+            testbench: ^9.17
           - laravel: 12.*
             php: 8.2
-            testbench: 10.*
+            testbench: ^10.11
           - laravel: 13.*
             php: 8.3
-            testbench: 11.*
+            testbench: ^11.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,21 +21,21 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0||^11.0",
-        "spatie/laravel-package-tools": "^1.14.0",
-        "sqids/sqids": "^0.4.1"
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
+        "spatie/laravel-package-tools": "^1.93.1",
+        "sqids/sqids": "^0.5.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
-        "nunomaduro/larastan": "^2.6",
-        "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.23",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "larastan/larastan": "^2.11||^3.10",
+        "nunomaduro/collision": "^7.10||^8.9.4",
+        "orchestra/testbench": "^8.13||^9.17||^10.11||^11.1",
+        "pestphp/pest": "^2.36||^3.8||^4.7",
+        "pestphp/pest-plugin-arch": "^2.7||^3.1||^4.0",
+        "pestphp/pest-plugin-laravel": "^2.4||^3.2||^4.1",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3"
+        "phpstan/phpstan-deprecation-rules": "^1.2||^2.0",
+        "phpstan/phpstan-phpunit": "^1.3||^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,4 +11,7 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
+    ignoreErrors:
+        -
+            identifier: trait.unused
+            path: src/Traits/*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,13 +20,6 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/src/Config/ConfigRepository.php
+++ b/src/Config/ConfigRepository.php
@@ -9,9 +9,7 @@ use StevenFox\LaravelSqids\Exceptions\NamedSqidConfigurationNotFoundException;
 
 readonly class ConfigRepository implements ConfigRepositoryInterface
 {
-    public function __construct(private Repository $config)
-    {
-    }
+    public function __construct(private Repository $config) {}
 
     public function hasSqidConfig(string $name): bool
     {

--- a/src/Config/SqidConfiguration.php
+++ b/src/Config/SqidConfiguration.php
@@ -4,14 +4,19 @@ namespace StevenFox\LaravelSqids\Config;
 
 class SqidConfiguration
 {
+    /**
+     * @param  array<int, string>  $blocklist
+     */
     public function __construct(
         public string $name,
         public string $alphabet,
         public int $minLength,
         public array $blocklist,
-    ) {
-    }
+    ) {}
 
+    /**
+     * @return array{name: string, alphabet: string, minLength: int, blocklist: array<int, string>}
+     */
     public function toArray(): array
     {
         return [

--- a/src/Contracts/ConfigBasedSqidder.php
+++ b/src/Contracts/ConfigBasedSqidder.php
@@ -6,5 +6,5 @@ use Sqids\SqidsInterface;
 
 interface ConfigBasedSqidder extends SqidsInterface
 {
-    public function forConfig(string $name = null): static;
+    public function forConfig(?string $name = null): static;
 }

--- a/src/Facades/Sqidder.php
+++ b/src/Facades/Sqidder.php
@@ -7,9 +7,9 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @see \StevenFox\LaravelSqids\Sqidder
  *
- * @method static string encode(array $numbers)
- * @method static array decode(string $id)
- * @method static \StevenFox\LaravelSqids\Sqidder forConfig(string $name = null)
+ * @method static string encode(array<int, int> $numbers)
+ * @method static array<int, int> decode(string $id)
+ * @method static \StevenFox\LaravelSqids\Sqidder forConfig(?string $name = null)
  */
 class Sqidder extends Facade
 {

--- a/src/Factories/CoderFactory.php
+++ b/src/Factories/CoderFactory.php
@@ -12,8 +12,7 @@ class CoderFactory implements CoderFactoryInterface
 {
     public function __construct(
         private ConfigRepository $configRepository
-    ) {
-    }
+    ) {}
 
     public function forConfig(SqidConfiguration $config): SqidsInterface
     {

--- a/src/LaravelSqidsServiceProvider.php
+++ b/src/LaravelSqidsServiceProvider.php
@@ -40,6 +40,9 @@ class LaravelSqidsServiceProvider extends PackageServiceProvider implements Defe
         $this->app->alias('sqidder', SqidderFacade::class);
     }
 
+    /**
+     * @return array<int, class-string|string>
+     */
     public function provides(): array
     {
         return [

--- a/src/ModelSqidders/ModelSqidder.php
+++ b/src/ModelSqidders/ModelSqidder.php
@@ -17,9 +17,7 @@ class ModelSqidder
 {
     use MakesEncodedAndDecodedSqidInstances;
 
-    public function __construct(protected Model $model)
-    {
-    }
+    public function __construct(protected Model $model) {}
 
     /**
      * @return TEncodedSqid

--- a/src/Sqidder.php
+++ b/src/Sqidder.php
@@ -10,21 +10,26 @@ class Sqidder implements ConfigBasedSqidder
     public function __construct(
         private Contracts\CoderFactory $coderFactory,
         private ?string $sqidConfigName = null,
-    ) {
-    }
+    ) {}
 
-    public function forConfig(string $name = null): static
+    public function forConfig(?string $name = null): static
     {
         $this->sqidConfigName = $name;
 
         return $this;
     }
 
+    /**
+     * @param  array<int, int>  $numbers
+     */
     public function encode(array $numbers): string
     {
         return $this->coder()->encode($numbers);
     }
 
+    /**
+     * @return array<int, int>
+     */
     public function decode(string $id): array
     {
         return $this->coder()->decode($id);

--- a/src/Sqids/DecodedSqid.php
+++ b/src/Sqids/DecodedSqid.php
@@ -14,9 +14,12 @@ class DecodedSqid
 
     protected ConfigBasedSqidder $sqidder;
 
+    /**
+     * @param  array<int, int>  $numbers
+     */
     final public function __construct(
         protected array $numbers,
-        ConfigBasedSqidder $sqidder = null,
+        ?ConfigBasedSqidder $sqidder = null,
     ) {
         $sqidder ??= app(ConfigBasedSqidder::class);
         $this->sqidder = $sqidder->forConfig($this->configName());
@@ -28,11 +31,11 @@ class DecodedSqid
     }
 
     /**
-     * @param  int[]  $numbers
+     * @param  array<int, int>  $numbers
      */
-    public static function newFromArray(array $numbers): static
+    public static function newFromArray(array $numbers, ?ConfigBasedSqidder $sqidder = null): static
     {
-        return new static($numbers);
+        return new static($numbers, $sqidder);
     }
 
     public function encode(): EncodedSqid
@@ -42,6 +45,9 @@ class DecodedSqid
         );
     }
 
+    /**
+     * @return array<int, int>
+     */
     public function numbers(): array
     {
         return $this->numbers;
@@ -70,7 +76,7 @@ class DecodedSqid
         /** @var class-string<EncodedSqid> $encodedSqidClass */
         $encodedSqidClass = $this->encodedSqidClass();
 
-        return $encodedSqidClass::new($id);
+        return $encodedSqidClass::new($id, $this->sqidder);
     }
 
     /**

--- a/src/Sqids/EncodedSqid.php
+++ b/src/Sqids/EncodedSqid.php
@@ -17,16 +17,16 @@ class EncodedSqid
 
     final public function __construct(
         protected string $id,
-        ConfigBasedSqidder $sqidder = null,
+        ?ConfigBasedSqidder $sqidder = null,
     ) {
         /** @var ?ConfigBasedSqidder $sqidder */
         $sqidder ??= app(ConfigBasedSqidder::class);
         $this->sqidder = $sqidder->forConfig($this->configName());
     }
 
-    public static function new(string $id): static
+    public static function new(string $id, ?ConfigBasedSqidder $sqidder = null): static
     {
-        return new static($id);
+        return new static($id, $sqidder);
     }
 
     public function decodeOrFail(): DecodedSqid
@@ -93,12 +93,15 @@ class EncodedSqid
         return $this->configName;
     }
 
+    /**
+     * @param  array<int, int>  $numbers
+     */
     public function makeDecodedSqid(array $numbers): DecodedSqid
     {
         /** @var class-string<DecodedSqid> $decodedSqidClass */
         $decodedSqidClass = $this->decodedSqidClass();
 
-        return $decodedSqidClass::newFromArray($numbers);
+        return $decodedSqidClass::newFromArray($numbers, $this->sqidder);
     }
 
     /**

--- a/src/Traits/EncodesModelAttributesToSqid.php
+++ b/src/Traits/EncodesModelAttributesToSqid.php
@@ -3,7 +3,11 @@
 namespace StevenFox\LaravelSqids\Traits;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @phpstan-require-extends Model
+ */
 trait EncodesModelAttributesToSqid
 {
     use HasAttributesSqidder;

--- a/src/Traits/HasAttributesSqidder.php
+++ b/src/Traits/HasAttributesSqidder.php
@@ -2,8 +2,12 @@
 
 namespace StevenFox\LaravelSqids\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use StevenFox\LaravelSqids\ModelSqidders\ModelSqidder;
 
+/**
+ * @phpstan-require-extends Model
+ */
 trait HasAttributesSqidder
 {
     /**

--- a/src/Traits/MakesEncodedAndDecodedSqidInstances.php
+++ b/src/Traits/MakesEncodedAndDecodedSqidInstances.php
@@ -23,6 +23,9 @@ trait MakesEncodedAndDecodedSqidInstances
         return EncodedSqid::class;
     }
 
+    /**
+     * @param  array<int, int>  $numbers
+     */
     protected function makeDecodedSqid(array $numbers): DecodedSqid
     {
         /** @var class-string<DecodedSqid> $class */

--- a/src/Traits/ResolvesRouteBindingWithSqid.php
+++ b/src/Traits/ResolvesRouteBindingWithSqid.php
@@ -6,6 +6,9 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use StevenFox\LaravelSqids\Exceptions\CannotDecodeSqidToAttributesArray;
 
+/**
+ * @phpstan-require-extends Model
+ */
 trait ResolvesRouteBindingWithSqid
 {
     use MakesEncodedAndDecodedSqidInstances;

--- a/tests/CoderFactoryTest.php
+++ b/tests/CoderFactoryTest.php
@@ -10,7 +10,7 @@ beforeEach(function () {
 });
 
 it('implements the CoderFactory interface', function () {
-    expect($this->factory)->toBeInstanceOf(\StevenFox\LaravelSqids\Contracts\CoderFactory::class);
+    expect($this->factory)->toBeInstanceOf(StevenFox\LaravelSqids\Contracts\CoderFactory::class);
 });
 
 it('can make a SqidsInterface instance for a SqidConfiguration', function () {

--- a/tests/ConfigRepositoryTest.php
+++ b/tests/ConfigRepositoryTest.php
@@ -10,7 +10,7 @@ beforeEach(function () {
 });
 
 it('implements the ConfigRepository interface', function () {
-    expect($this->repo)->toBeInstanceOf(\StevenFox\LaravelSqids\Contracts\ConfigRepository::class);
+    expect($this->repo)->toBeInstanceOf(StevenFox\LaravelSqids\Contracts\ConfigRepository::class);
 });
 
 it('can determine if a sqid config exists for a given name', function () {

--- a/tests/EncodesModelAttributesToSqidTest.php
+++ b/tests/EncodesModelAttributesToSqidTest.php
@@ -18,13 +18,13 @@ it('the sqid attribute will use a custom model sqidder', function () {
 });
 
 it('will append the sqid on the model by default', function () {
-    $model = new SqidModel();
+    $model = new SqidModel;
 
     expect($model->hasAppended('sqid'))->toBeTrue();
 });
 
 it('appending the sqid can be overridden', function () {
-    $model = new NonAppendingModel();
+    $model = new NonAppendingModel;
 
     expect($model->hasAppended('sqid'))->toBeFalse();
 });

--- a/tests/HasAttributesSqidderTest.php
+++ b/tests/HasAttributesSqidderTest.php
@@ -5,19 +5,19 @@ use StevenFox\LaravelSqids\ModelSqidders\ModelSqidder;
 use StevenFox\LaravelSqids\Traits\HasAttributesSqidder;
 
 it('has a sqidder method that returns a ModelSqidder by default', function () {
-    $model = new HasAttributesSqidderModel();
+    $model = new HasAttributesSqidderModel;
 
     expect($model->sqidder())->toBeInstanceOf(ModelSqidder::class);
 });
 
 test('the sqidder method can be overridden to provide a custom model sqidder', function () {
-    $model = new CustomSqidderBySqidderMethodModel();
+    $model = new CustomSqidderBySqidderMethodModel;
 
     expect($model->sqidder())->toBeInstanceOf(HasAttributesSqidderTestCustomSqidder::class);
 });
 
 it('has a sqidderClass method that permits overriding the sqidder type', function () {
-    $model = new CustomSqidderByClassNameSqidModel();
+    $model = new CustomSqidderByClassNameSqidModel;
 
     expect($model->sqidder())->toBeInstanceOf(HasAttributesSqidderTestCustomSqidder::class);
 });
@@ -47,6 +47,4 @@ class CustomSqidderBySqidderMethodModel extends Model
     }
 }
 
-class HasAttributesSqidderTestCustomSqidder extends ModelSqidder
-{
-}
+class HasAttributesSqidderTestCustomSqidder extends ModelSqidder {}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -9,13 +9,13 @@ use StevenFox\LaravelSqids\Sqidder;
 it('binds the config repository to the app container', function () {
     expect(app(ConfigRepository::class))
         ->toBeInstanceOf(ConfigRepository::class)
-        ->toBeInstanceOf(\StevenFox\LaravelSqids\Config\ConfigRepository::class);
+        ->toBeInstanceOf(StevenFox\LaravelSqids\Config\ConfigRepository::class);
 });
 
 it('binds the coder factory to the app container', function () {
     expect(app(CoderFactory::class))
         ->toBeInstanceOf(CoderFactory::class)
-        ->toBeInstanceOf(\StevenFox\LaravelSqids\Factories\CoderFactory::class);
+        ->toBeInstanceOf(StevenFox\LaravelSqids\Factories\CoderFactory::class);
 });
 
 it('binds a Sqidder to the app container via the "sqidder" name', function () {

--- a/tests/SqidderTest.php
+++ b/tests/SqidderTest.php
@@ -49,6 +49,6 @@ it('will use the default config when a null value is passed to the forConfig met
 });
 
 it('has a facade', function () {
-    expect(\StevenFox\LaravelSqids\Facades\Sqidder::getFacadeRoot())
+    expect(StevenFox\LaravelSqids\Facades\Sqidder::getFacadeRoot())
         ->toBeInstanceOf(Sqidder::class);
 });


### PR DESCRIPTION
## Summary
- expand Laravel compatibility to versions 10 through 13
- update package/dev dependency ranges, including Sqids 0.5 and Larastan package rename
- update PHPStan compatibility
- update CI to test Laravel/Testbench version combinations on Ubuntu
- remove default PHPUnit coverage reports so normal CI runs do not require a coverage driver